### PR TITLE
Add subtasks

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -103,6 +103,7 @@ class TodoistPluginSettingTab extends PluginSettingTab {
 
 		this.addApiKeySetting(containerEl);
 		this.addEnableAutomaticReplacementSetting(containerEl);
+		this.addIncludeSubttasksSetting(containerEl);
 		this.addKeywordTodoistQuerySetting(containerEl);
 		this.addExcludedDirectoriesSetting(containerEl);
 	}
@@ -117,6 +118,19 @@ class TodoistPluginSettingTab extends PluginSettingTab {
 				t.setValue(this.plugin.settings.enableAutomaticReplacement)
 					.onChange(async (value) => {
 							this.plugin.settings.enableAutomaticReplacement = value;
+							await this.plugin.saveSettings();
+						}
+					));
+	}
+
+	private addIncludeSubttasksSetting(containerEl: HTMLElement) {
+		new Setting(containerEl)
+			.setName('Enable Subtasks')
+			.setDesc("When enabled, any Subtasks associated with Todos meeting filter criteria from your keyword will be shown, indented, under the parent Todo.")
+			.addToggle(t =>
+				t.setValue(this.plugin.settings.showSubtasks)
+					.onChange(async (value) => {
+							this.plugin.settings.showSubtasks = value;
 							await this.plugin.saveSettings();
 						}
 					));

--- a/src/DefaultSettings.ts
+++ b/src/DefaultSettings.ts
@@ -6,6 +6,7 @@ export interface TodoistSettings {
 	keywordToTodoistQuery: keywordTodoistQuery[];
 	authToken: string;
 	enableAutomaticReplacement: boolean;
+	showSubtasks: boolean;
 	// never rely on adding a new default value. Any change should entail bumping the settingsVersion
 	// and adding a settings migration
 }
@@ -16,9 +17,10 @@ export interface keywordTodoistQuery {
 }
 
 export const DEFAULT_SETTINGS: TodoistSettings = {
-	settingsVersion: 1,
+	settingsVersion: 2,
 	excludedDirectories: [],
 	keywordToTodoistQuery: [{keyword: "@@TODOIST@@", todoistQuery: "today|overdue"}],
 	authToken: "TODO - get your auth token",
-	enableAutomaticReplacement: true
+	enableAutomaticReplacement: true,
+	showSubtasks: true
 }

--- a/src/settingsMigrator.test.ts
+++ b/src/settingsMigrator.test.ts
@@ -33,7 +33,9 @@ test('v1 custom to v1 migration', () => {
 		enableAutomaticReplacement: false,
 		excludedDirectories: ["some_exc_dir"],
 		keywordToTodoistQuery: [{keyword: "key_a", todoistQuery: "query_a"}, {keyword: "key_b", todoistQuery: "query_b"}],
-		settingsVersion: 1
+		settingsVersion: 1,
+		showSubtasks: true
 	}
 	expect(migrateSettings(v1alreadySetSettings)).toStrictEqual(v1alreadySetSettings)
 })
+

--- a/src/settingsMigrator.ts
+++ b/src/settingsMigrator.ts
@@ -1,7 +1,12 @@
-import {TodoistSettings} from "./DefaultSettings";
+import {TodoistSettings, keywordTodoistQuery} from "./DefaultSettings";
 
 export function migrateSettings(settings: any) : TodoistSettings {
 	let newSettings : any = settings;
+
+	if (getSettingsVersion(newSettings) == 1) {
+		newSettings = migrateToV2(settings as TodoistSettingV1)
+	}
+
 	if (getSettingsVersion(newSettings) == 0) {
 		newSettings = migrateToV1(settings as TodoistSettingV0)
 	}
@@ -20,7 +25,19 @@ function migrateToV1(settings: TodoistSettingV0) : TodoistSettings {
 		enableAutomaticReplacement: settings.enableAutomaticReplacement,
 		excludedDirectories: settings.excludedDirectories,
 		keywordToTodoistQuery: [{keyword: settings.templateString, todoistQuery: settings.todoistQuery}],
+		showSubtasks: true,
 		settingsVersion: 1
+	};
+}
+
+function migrateToV2(settings: TodoistSettingV1) : TodoistSettings {
+	return {
+		authToken: settings.authToken,
+		enableAutomaticReplacement: settings.enableAutomaticReplacement,
+		excludedDirectories: settings.excludedDirectories,
+		keywordToTodoistQuery: settings.keywordToTodoistQuery,
+		showSubtasks: true,
+		settingsVersion: 2
 	};
 }
 
@@ -30,4 +47,12 @@ interface TodoistSettingV0 {
 	templateString: string;
 	authToken: string;
 	todoistQuery: string;
+}
+
+interface TodoistSettingV1 {
+	enableAutomaticReplacement: boolean;
+	excludedDirectories: string[];
+	templateString: string;
+	authToken: string;
+	keywordToTodoistQuery: keywordTodoistQuery[];
 }

--- a/src/updateFileFromServer.ts
+++ b/src/updateFileFromServer.ts
@@ -77,8 +77,12 @@ async function getServerData(todoistQuery: string, authToken: string, showSubtas
 	const api = new TodoistApi(authToken)
 
 	const tasks = await callTasksApi(api, todoistQuery);
-	const subtasks = await callTasksApi(api, 'subtask');
 
+	let subtasks: Task[];
+	if (showSubtasks) {
+		subtasks = await callTasksApi(api, 'subtask');
+	}
+	
 	if (tasks.length === 0){
 		new Notice(`Todoist text: You have no tasks matching filter "${todoistQuery}"`);
 	}

--- a/src/updateFileFromServer.ts
+++ b/src/updateFileFromServer.ts
@@ -23,7 +23,7 @@ export async function updateFileFromServer(settings: TodoistSettings, app: App) 
 			console.log("Todoist Text: Updating keyword with todos. If this happened automatically and you did not intend for this " +
 				"to happen, you should either disable automatic replacement of your keyword with todos (via the settings), or" +
 				" exclude this file from auto replace (via the settings).")
-			const formattedTodos = await getServerData(keywordToQuery.todoistQuery, settings.authToken);
+			const formattedTodos = await getServerData(keywordToQuery.todoistQuery, settings.authToken, settings.showSubtasks);
 
 			// re-read file contents to reduce race condition after slow server call
 			fileContents = await app.vault.read(file)
@@ -73,7 +73,7 @@ export async function toggleServerTaskStatus(e: Editor, settings: TodoistSetting
 	}
 }
 
-async function getServerData(todoistQuery: string, authToken: string): Promise<string> {
+async function getServerData(todoistQuery: string, authToken: string, showSubtasks: boolean): Promise<string> {
 	const api = new TodoistApi(authToken)
 
 	const tasks = await callTasksApi(api, todoistQuery);
@@ -86,7 +86,10 @@ async function getServerData(todoistQuery: string, authToken: string): Promise<s
 		let returnString = ""
 		returnString = returnString.concat(getFormattedTaskDetail(t, 0));
 		
-		returnString = returnString.concat(getSubTasks(subtasks, t.id, 1));
+		if (showSubtasks) {
+			returnString = returnString.concat(getSubTasks(subtasks, t.id, 1));
+		}
+		
 		return returnString;
 	})
 	return formattedTasks.join("\n")

--- a/src/updateFileFromServer.ts
+++ b/src/updateFileFromServer.ts
@@ -73,7 +73,6 @@ export async function toggleServerTaskStatus(e: Editor, settings: TodoistSetting
 	}
 }
 
-
 async function getServerData(todoistQuery: string, authToken: string): Promise<string> {
 	const api = new TodoistApi(authToken)
 
@@ -132,8 +131,17 @@ function getSubTasks(subtasks: Task[], parentId: string, indent: number): string
 function getFormattedTaskDetail(task: Task, indent: number): string {	
 	let description = getTaskDescription(task.description, indent);
 	let tabs = "\t".repeat(indent);
+
+	// used to fix the difference between the app and API (https://github.com/Doist/todoist-python/issues/18)
+	const priorityMap = new Map<number, number>([
+		[1, 4],
+		[2, 3],
+		[3, 2],
+		[4, 1]
+	])
+
 	let addnewline = indent > 0 ? `\n` : "";
-	return `${addnewline}${tabs}- [ ] ${task.content} -- p${task.priority} -- [src](${task.url}) ${description}`;
+	return `${addnewline}${tabs}- [ ] ${task.content} -- p${priorityMap.get(task.priority)} -- [src](${task.url}) ${description}`;
 }
 
 function getTaskDescription(description: string, indent: number): string {


### PR DESCRIPTION
Adds a subtask capture feature (with related setting) per discussion in issue #12.

### Additions

* Broke out 3 separate functions to minimize repetition.
  * Note: Hoping this might also help with #5 in the future, possibly starting the setup to do a token replacement?
* Added API call for subtasks (only fires when setting enabled).
* Added processing for subtask detail.

### Manual Testing

* New setting works correctly (enabled grabs subtasks, disabled bypasses).
* Task string and description renders correctly (also see Extra Bonus Fix section below).
* Indentation works as expected for subtasks and descriptions.
* Toggling the status works properly for subtasks.
* Created a number of tasks and subtasks for testing.
   * I don't know what the breaking point of the API and/or Obsidian is, so not sure if I stressed it enough.
* Error handling exercised (as good as I could) to minimize any unhandled exceptions or issues.

![image](https://user-images.githubusercontent.com/1332880/209891932-55789ccf-6263-4bea-a036-dae16b5ce8ec.png)

### Unit Tests
I did update the tests for the settings migration, but I'm not sure that I did it properly.  After a bit of poking around, I'm also not positive that it's testing 100% either?  I updated the default settings, but the v0 to v1 migration didn't break.  It's passing, even though the settingsVersion in there is still 1, not the updated version of 2.

### Extra Bonus Fix - API Task Priority

When I broke out the formatting of the task detail to a separate function, I discovered during testing that the priority value of a task is reversed in the API compared to what gets set in the app.  All the "everything else" priority 4 tasks were getting displayed as p1 (since that's what the API returned).

![priority-before](https://user-images.githubusercontent.com/1332880/209890984-1f3ebf26-95ef-4ca2-817b-2227637efa62.png)

I found another archived repo/issue discussing this: https://github.com/Doist/todoist-python/issues/18.  I added a lookup in the new getFormattedTaskDetail function to resolve.  If additional priority values are added by Todoist in the future the plugin won't break, the task priority will just show as the always fun "undefined".

![priority-after](https://user-images.githubusercontent.com/1332880/209890992-71db13ea-737a-42eb-9b3c-57182a3ab186.png)

![priority-undefined](https://user-images.githubusercontent.com/1332880/209890998-70d17ef8-ced3-4c3f-af26-f32166592ea5.png)