### PR TITLE
fix setting migrator bug

### DIFF
--- a/src/settingsMigrator.test.ts
+++ b/src/settingsMigrator.test.ts
@@ -1,7 +1,7 @@
 import {migrateSettings} from "./settingsMigrator";
 import {DEFAULT_SETTINGS, TodoistSettings} from "./DefaultSettings";
 
-test('v0 to v1 migration', () => {
+test('v0 to v2 migration', () => {
 	const v0Settings = {
 		excludedDirectories: ["old_exc_dir"],
 		templateString: "old_custom_template",
@@ -9,7 +9,7 @@ test('v0 to v1 migration', () => {
 		todoistQuery: "old_todoist_query",
 		enableAutomaticReplacement: false
 	}
-	const latestSettings = {
+	const expected = {
 		authToken: "old_auth_token",
 		"enableAutomaticReplacement": false,
 		"excludedDirectories": [
@@ -18,23 +18,47 @@ test('v0 to v1 migration', () => {
 		"keywordToTodoistQuery": [
 			{"keyword": "old_custom_template", "todoistQuery": "old_todoist_query"},
 		],
-		"settingsVersion": 1
+		"settingsVersion": 2,
+		"showSubtasks": true,
 	}
-	expect(migrateSettings(v0Settings)).toStrictEqual(latestSettings);
+	expect(migrateSettings(v0Settings)).toStrictEqual(expected);
+});
+
+test('v1 to v2 migration', () => {
+	const v0Settings = {
+		excludedDirectories: ["old_exc_dir"],
+		templateString: "old_custom_template",
+		authToken: "old_auth_token",
+		todoistQuery: "old_todoist_query",
+		enableAutomaticReplacement: false,
+	}
+	const expected = {
+		authToken: "old_auth_token",
+		enableAutomaticReplacement: false,
+		excludedDirectories: [
+			"old_exc_dir"
+		],
+		keywordToTodoistQuery: [
+			{"keyword": "old_custom_template", "todoistQuery": "old_todoist_query"},
+		],
+		settingsVersion: 2,
+		showSubtasks: true,
+	}
+	expect(migrateSettings(v0Settings)).toStrictEqual(expected);
 });
 
 test('v1 default to v1 migration', () => {
 	expect(migrateSettings(DEFAULT_SETTINGS)).toStrictEqual(DEFAULT_SETTINGS)
 })
 
-test('v1 custom to v1 migration', () => {
+test('v2 custom to v2 migration', () => {
 	const v1alreadySetSettings: TodoistSettings = {
 		authToken: "some_auth_token",
 		enableAutomaticReplacement: false,
 		excludedDirectories: ["some_exc_dir"],
 		keywordToTodoistQuery: [{keyword: "key_a", todoistQuery: "query_a"}, {keyword: "key_b", todoistQuery: "query_b"}],
-		settingsVersion: 1,
-		showSubtasks: true
+		settingsVersion: 2,
+		showSubtasks: false
 	}
 	expect(migrateSettings(v1alreadySetSettings)).toStrictEqual(v1alreadySetSettings)
 })

--- a/src/settingsMigrator.ts
+++ b/src/settingsMigrator.ts
@@ -4,11 +4,11 @@ export function migrateSettings(settings: any) : TodoistSettings {
 	let newSettings : any = settings;
 
 	if (getSettingsVersion(newSettings) == 0) {
-		newSettings = migrateToV1(settings as TodoistSettingV0)
+		newSettings = migrateToV1(newSettings as TodoistSettingV0)
 	}
 
 	if (getSettingsVersion(newSettings) == 1) {
-		newSettings = migrateToV2(settings as TodoistSettingV1)
+		newSettings = migrateToV2(newSettings)
 	}
 
 	return newSettings;
@@ -19,13 +19,13 @@ function getSettingsVersion(settings: any) : number {
 	return settings.settingsVersion ?? 0;
 }
 
-function migrateToV1(settings: TodoistSettingV0) : TodoistSettings {
+function migrateToV1(settings: TodoistSettingV0) : TodoistSettingV1 {
 	return {
 		authToken: settings.authToken,
 		enableAutomaticReplacement: settings.enableAutomaticReplacement,
+		templateString: settings.templateString,
 		excludedDirectories: settings.excludedDirectories,
 		keywordToTodoistQuery: [{keyword: settings.templateString, todoistQuery: settings.todoistQuery}],
-		showSubtasks: true,
 		settingsVersion: 1
 	};
 }
@@ -47,6 +47,7 @@ interface TodoistSettingV0 {
 	templateString: string;
 	authToken: string;
 	todoistQuery: string;
+	settingsVersion: number;
 }
 
 interface TodoistSettingV1 {
@@ -55,4 +56,5 @@ interface TodoistSettingV1 {
 	templateString: string;
 	authToken: string;
 	keywordToTodoistQuery: keywordTodoistQuery[];
+	settingsVersion: number;
 }


### PR DESCRIPTION
fix bug (where the old settingsObject was being passed through instead of the new one), and unit test (which is what caught the regression)

FYI @madajczyk  - i'll merge this once you have a chance to look at it and confirm this is the right fix. I hadn't yet deployed your PR, so fortunate timing there!